### PR TITLE
Fix/avoid overwrite user defined env

### DIFF
--- a/common/envOverwrite/overwriter.go
+++ b/common/envOverwrite/overwriter.go
@@ -56,61 +56,6 @@ var EnvValuesMap = map[string]envValues{
 	},
 }
 
-func GetPatchedEnvValueAndIgnoreObservedValue(envName string, observedValue string, currentSdk common.OtelSdk) *string {
-	envMetadata, ok := EnvValuesMap[envName]
-	if !ok {
-		// Odigos does not manipulate this environment variable, so ignore it
-		return nil
-	}
-
-	desiredOdigosPart, ok := envMetadata.values[currentSdk]
-	if !ok {
-		// No specific overwrite is required for this SDK
-		return nil
-	}
-
-	// scenario 1: no user defined values and no odigos value
-	// happens: might be the case right after the source is instrumented, and before the instrumentation is applied.
-	// action: there are no user defined values, so no need to make any changes.
-	if observedValue == "" {
-		return nil
-	}
-
-	// scenario 2: no user defined values, only odigos value
-	// happens: when the user did not set any value to this env (either via manifest or dockerfile)
-	// action: we don't need to overwrite the value, just let odigos handle it
-	for _, sdkEnvValue := range envMetadata.values {
-		if sdkEnvValue == observedValue {
-			return nil
-		}
-	}
-
-	// Scenario 3: both odigos and user defined values are present
-	// happens: when the user set some values to this env (either via manifest or dockerfile) and odigos instrumentation is applied.
-	// action: we want to keep the user defined values and upsert the odigos value.
-	for _, sdkEnvValue := range envMetadata.values {
-		if strings.Contains(observedValue, sdkEnvValue) {
-			if sdkEnvValue == desiredOdigosPart {
-				// shortcut, the value is already patched
-				// both the odigos part equals to the new value, and the user part we want to keep
-				return &observedValue
-			} else {
-				// The environment variable is patched by some other odigos sdk.
-				// replace just the odigos part with the new desired value.
-				// this can happen when moving between SDKs.
-				patchedEvnValue := strings.ReplaceAll(observedValue, sdkEnvValue, desiredOdigosPart)
-				return &patchedEvnValue
-			}
-		}
-	}
-
-	// Scenario 4: only user defined values are present
-	// happens: when the user set some values to this env (either via manifest or dockerfile) and odigos instrumentation not yet applied.
-	// action: we want to keep the user defined values and append the odigos value.
-	mergedEnvValue := desiredOdigosPart
-	return &mergedEnvValue
-}
-
 func GetPatchedEnvValue(envName string, observedValue string, currentSdk common.OtelSdk) *string {
 	envMetadata, ok := EnvValuesMap[envName]
 	if !ok {

--- a/common/envOverwrite/overwriter_admission.go
+++ b/common/envOverwrite/overwriter_admission.go
@@ -1,0 +1,44 @@
+package envOverwrite
+
+import (
+	"github.com/odigos-io/odigos/common"
+)
+
+// Since patches has been stored into annotations
+// the environment variables in the Pod admission has user-defined part only.
+// we will append the part defined by Odigos if needed
+// return nil if no change needs
+func PatchedEnvValueWithOdigosPart(envName string, envValue string, currentSdk common.OtelSdk) *string {
+	envMetadata, ok := EnvValuesMap[envName]
+	if !ok {
+		// Odigos does not manipulate this environment variable, so ignore it
+		return nil
+	}
+
+	desiredOdigosPart, ok := envMetadata.values[currentSdk]
+	if !ok {
+		// No specific overwrite is required for this SDK
+		return nil
+	}
+
+	mergedEnvValue := envValue + envMetadata.delim + desiredOdigosPart
+	return &mergedEnvValue
+}
+
+// Compared to PatchedEnvValueWithOdigosPart, user-configured variables are no longer applied.
+func PatchedEnvValueOnlyWithOdigosPart(envName string, currentSdk common.OtelSdk) *string {
+	envMetadata, ok := EnvValuesMap[envName]
+	if !ok {
+		// Odigos does not manipulate this environment variable, so ignore it
+		return nil
+	}
+
+	desiredOdigosPart, ok := envMetadata.values[currentSdk]
+	if !ok {
+		// No specific overwrite is required for this SDK
+		return nil
+	}
+
+	mergedEnvValue := desiredOdigosPart
+	return &mergedEnvValue
+}

--- a/instrumentor/instrumentation/instrumentation.go
+++ b/instrumentor/instrumentation/instrumentation.go
@@ -189,7 +189,7 @@ func patchEnvVarsForContainer(runtimeDetails *odigosv1.InstrumentedApplication, 
 
 	// Used for ENV defined in Dockerfile
 	// Supplement the variables defined by the user inside the container into the manifest, and append the Odigos part.
-	if OverwriteUserDefinedEnvs {
+	if !OverwriteUserDefinedEnvs {
 		// Step 2: add the new env vars which odigos might patch, but which are not defined in the manifest
 		for envName, envValue := range observedEnvs {
 			desiredEnvValue := envOverwrite.GetPatchedEnvValue(envName, envValue, sdk)

--- a/instrumentor/instrumentation/instrumentation.go
+++ b/instrumentor/instrumentation/instrumentation.go
@@ -150,23 +150,12 @@ func getEnvVarsOfContainer(instrumentation *odigosv1.InstrumentedApplication, co
 }
 
 func patchEnvVarsForContainer(runtimeDetails *odigosv1.InstrumentedApplication, container *corev1.Container, obj client.Object, sdk common.OtelSdk, manifestEnvOriginal *envoverwrite.OrigWorkloadEnvValues) error {
-
 	observedEnvs := getEnvVarsOfContainer(runtimeDetails, container.Name)
 
 	// Step 1: check existing environment on the manifest and update them if needed
 	newEnvs := make([]corev1.EnvVar, 0, len(container.Env))
 	for _, envVar := range container.Env {
-
-		// extract the observed value for this env var, which might be empty if not currently exists
-		observedEnvValue := observedEnvs[envVar.Name]
-
-		var desiredEnvValue *string
-		if OverwriteUserDefinedEnvs {
-			desiredEnvValue = envOverwrite.GetPatchedEnvValueAndIgnoreObservedValue(envVar.Name, observedEnvValue, sdk)
-		} else {
-			desiredEnvValue = envOverwrite.GetPatchedEnvValue(envVar.Name, observedEnvValue, sdk)
-		}
-
+		var desiredEnvValue = envOverwrite.PatchedEnvValueWithOdigosPart(envVar.Name, envVar.Value, sdk)
 		if desiredEnvValue == nil {
 			// no need to patch this env var, so make sure it is reverted to its original value
 			origValue, found := manifestEnvOriginal.RemoveOriginalValue(container.Name, envVar.Name)
@@ -198,17 +187,21 @@ func patchEnvVarsForContainer(runtimeDetails *odigosv1.InstrumentedApplication, 
 		delete(observedEnvs, envVar.Name)
 	}
 
-	// Step 2: add the new env vars which odigos might patch, but which are not defined in the manifest
-	for envName, envValue := range observedEnvs {
-		desiredEnvValue := envOverwrite.GetPatchedEnvValue(envName, envValue, sdk)
-		if desiredEnvValue != nil {
-			// store that it was empty to begin with
-			manifestEnvOriginal.InsertOriginalValue(container.Name, envName, nil)
-			// and add this new env var to the manifest
-			newEnvs = append(newEnvs, corev1.EnvVar{
-				Name:  envName,
-				Value: *desiredEnvValue,
-			})
+	// Used for ENV defined in Dockerfile
+	// Supplement the variables defined by the user inside the container into the manifest, and append the Odigos part.
+	if OverwriteUserDefinedEnvs {
+		// Step 2: add the new env vars which odigos might patch, but which are not defined in the manifest
+		for envName, envValue := range observedEnvs {
+			desiredEnvValue := envOverwrite.GetPatchedEnvValue(envName, envValue, sdk)
+			if desiredEnvValue != nil {
+				// store that it was empty to begin with
+				manifestEnvOriginal.InsertOriginalValue(container.Name, envName, nil)
+				// and add this new env var to the manifest
+				newEnvs = append(newEnvs, corev1.EnvVar{
+					Name:  envName,
+					Value: *desiredEnvValue,
+				})
+			}
 		}
 	}
 

--- a/instrumentor/main.go
+++ b/instrumentor/main.go
@@ -181,10 +181,17 @@ func createSetupManager() (*setup.SetupManager, error) {
 	if err != nil {
 		return nil, err
 	}
-	client, err := client.New(k8sCfg, client.Options{})
+	client, err := client.NewWithWatch(k8sCfg, client.Options{
+		Scheme: runtime.NewScheme(),
+	})
 	if err != nil {
 		return nil, err
 	}
+
+	if err := corev1.AddToScheme(client.Scheme()); err != nil {
+		return nil, err
+	}
+
 	smgr := setup.NewSetupManager(setupLog, setupCfg, client)
 	return smgr, nil
 }

--- a/instrumentor/setup/namespace.go
+++ b/instrumentor/setup/namespace.go
@@ -21,6 +21,9 @@ import (
  */
 
 type NamespaceInstrumentRule struct {
+	nsCfg map[string]any
+
+	checkedNamespace []string
 }
 
 func (r *NamespaceInstrumentRule) InstrumentAll(logger logr.Logger, c client.Client) ([]string, error) {
@@ -32,7 +35,6 @@ func (r *NamespaceInstrumentRule) InstrumentAll(logger logr.Logger, c client.Cli
 	}
 
 	var nsList []string
-
 	// TODO deal with error
 	for _, ns := range namespaceList.Items {
 		if ns.Name == "kube-system" || ns.Name == env.GetCurrentNamespace() {
@@ -46,11 +48,14 @@ func (r *NamespaceInstrumentRule) InstrumentAll(logger logr.Logger, c client.Cli
 			return nil, err
 		}
 	}
+
+	r.checkedNamespace = nsList
 	return nsList, nil
 }
 
 func (r *NamespaceInstrumentRule) InstrumentWithCfg(logger logr.Logger, c client.Client, cfg *viper.Viper, defaultEnable bool) ([]string, error) {
-	nsCfg := cfg.GetStringMap("namespace")
+	r.nsCfg = cfg.GetStringMap("namespace")
+
 	// List all namespaces in the cluster using the client
 	namespaceList := &corev1.NamespaceList{}
 	err := c.List(context.Background(), namespaceList)
@@ -66,7 +71,7 @@ func (r *NamespaceInstrumentRule) InstrumentWithCfg(logger logr.Logger, c client
 		}
 		logger.Info("check namespace", "name", ns.Name)
 		nsList = append(nsList, ns.Name)
-		op, find := nsCfg[ns.Name]
+		op, find := r.nsCfg[ns.Name]
 		isEnabled := checkIfEnabled(find, op, defaultEnable)
 		if !isEnabled {
 			value, find := ns.GetLabels()[consts.OdigosInstrumentationLabel]
@@ -82,7 +87,7 @@ func (r *NamespaceInstrumentRule) InstrumentWithCfg(logger logr.Logger, c client
 			return nsList, err
 		}
 	}
-
+	r.checkedNamespace = nsList
 	return nsList, nil
 }
 

--- a/instrumentor/setup/setup.go
+++ b/instrumentor/setup/setup.go
@@ -2,26 +2,39 @@ package setup
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"math"
+	"sync"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/go-logr/logr"
 	"github.com/odigos-io/odigos/common/consts"
+	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	"github.com/spf13/viper"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // 读取启动配置,对现有的注入项进行设置
 type SetupManager struct {
 	Cfg    *viper.Viper
-	client client.Client
+	client client.WithWatch
 	logger logr.Logger
 
 	namespaces NamespaceInstrumentRule
 	workloads  WorkloadInstrumentRule
+
+	instrumentAll      bool
+	forceInstrumentAll bool
+
+	mutex sync.Mutex
 }
 
-func NewSetupManager(logger logr.Logger, cfg *viper.Viper, client client.Client) *SetupManager {
+func NewSetupManager(logger logr.Logger, cfg *viper.Viper, client client.WithWatch) *SetupManager {
 	setup := &SetupManager{
 		Cfg:        cfg,
 		client:     client,
@@ -32,7 +45,8 @@ func NewSetupManager(logger logr.Logger, cfg *viper.Viper, client client.Client)
 
 	return setup
 }
-func (m *SetupManager) Start(context.Context) error {
+
+func (m *SetupManager) Start(ctx context.Context) error {
 	m.UpdateAnnotationsByRule()
 	m.logger.Info("setup manager sync config done")
 	m.Cfg.WatchConfig()
@@ -40,45 +54,160 @@ func (m *SetupManager) Start(context.Context) error {
 		m.UpdateAnnotationsByRule()
 		m.logger.Info("setup manager sync config done")
 	})
+
+	go m.WatchNamespace(ctx)
+	return nil
+}
+
+func (m *SetupManager) WatchNamespace(ctx context.Context) {
+	const (
+		initialRetryInterval = 5 * time.Second
+		maxRetryInterval     = 5 * time.Minute
+	)
+
+	retryInterval := initialRetryInterval
+	for {
+		select {
+		case <-ctx.Done():
+			m.logger.Info("stop watch namespace since stop signal")
+			return
+		default:
+			if err := m.watchAndPatch(ctx); err != nil {
+				m.logger.Error(err, "watch namespace is interrupted, wait for retry",
+					"retryInterval(s)", int(retryInterval.Seconds()))
+			} else {
+				retryInterval = initialRetryInterval
+				continue
+			}
+
+			select {
+			case <-time.After(retryInterval):
+				retryInterval = time.Duration(math.Min(float64(retryInterval)*2, float64(maxRetryInterval)))
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+func (m *SetupManager) watchAndPatch(ctx context.Context) error {
+	watcher, err := m.client.Watch(
+		ctx,
+		&corev1.NamespaceList{},
+		&client.ListOptions{},
+	)
+	if err != nil {
+		return err
+	}
+	defer watcher.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			event, isOpen := <-watcher.ResultChan()
+			if !isOpen {
+				return errors.New("watch namespace is interrupted unexpected")
+			}
+
+			if event.Type != watch.Added {
+				continue
+			}
+
+			nsObj, ok := event.Object.(*corev1.Namespace)
+			if !ok {
+				continue
+			}
+			if err := m.handleNamespaceCreation(ctx, nsObj); err != nil {
+				m.logger.Error(err, "failed to handler namespace create", "namespace", nsObj.Name)
+			}
+		}
+	}
+}
+
+func (m *SetupManager) handleNamespaceCreation(ctx context.Context, ns *corev1.Namespace) error {
+	if ns.Name == "kube-system" || ns.Name == env.GetCurrentNamespace() {
+		return nil
+	}
+
+	for _, nsName := range m.namespaces.checkedNamespace {
+		if nsName == ns.Name {
+			return nil
+		}
+	}
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.logger.Info("check namespace", "name", ns.Name)
+	op, find := m.namespaces.nsCfg[ns.Name]
+	isEnabled := checkIfEnabled(find, op, m.instrumentAll || m.forceInstrumentAll)
+	skipNSPatch := false
+	if !isEnabled {
+		value, find := ns.GetLabels()[consts.OdigosInstrumentationLabel]
+		if !find || value == "disabled" || value == "disable" {
+			skipNSPatch = true
+		} else {
+			m.logger.Info("uninstrument namespace", "name", ns.Name)
+		}
+	} else {
+		m.logger.Info("instrument namespace", "name", ns.Name)
+	}
+
+	if !skipNSPatch {
+		patch := getJsonMergePatchForInstrumentationLabel(isEnabled)
+		if err := m.client.Patch(context.Background(), ns, client.RawPatch(types.MergePatchType, patch)); err != nil {
+			return err
+		}
+	}
+
+	m.namespaces.checkedNamespace = append(m.namespaces.checkedNamespace, ns.Name)
+	err := m.workloads.InstrumentWithCfg(m.logger, m.client, ns.Name, m.Cfg, m.instrumentAll || m.forceInstrumentAll)
+	if err != nil {
+		m.logger.Error(err, "error instrument workload", "namespace", ns.Name)
+	}
 	return nil
 }
 
 func (m *SetupManager) UpdateAnnotationsByRule() {
-	var instrumentAll, forceInstrumentAll bool
-	instrumentAll = m.Cfg.GetBool("instrument-all-namespace")
-	forceInstrumentAll = m.Cfg.GetBool("force-instrument-all-namespace")
-	m.logger.Info("update annotations", "instrument-all-namespace", instrumentAll, "force-instrument-all-namespace", forceInstrumentAll)
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.instrumentAll = m.Cfg.GetBool("instrument-all-namespace")
+	m.forceInstrumentAll = m.Cfg.GetBool("force-instrument-all-namespace")
+	m.logger.Info(
+		"instrument default cfg", "instrument-all-namespace", m.instrumentAll,
+		"force-instrument-all-namespace", m.forceInstrumentAll,
+	)
 	// 强制注入所有的NS和workload
-	if forceInstrumentAll {
-		// TODO deal with error
+	if m.forceInstrumentAll {
 		// 对所有可访问的NS(跳过kube-system)添加注入标记
-		nsList, _ := m.namespaces.InstrumentAll(m.logger, m.client)
+		nsList, err := m.namespaces.InstrumentAll(m.logger, m.client)
+		if err != nil {
+			m.logger.Error(err, "instrument namespace failed")
+		}
 		// 同时向所有可访问的workload添加注入标记
 		for _, namespace := range nsList {
-			// TODO deal with error
-			_ = m.workloads.InstrumentAll(m.logger, m.client, namespace)
+			err = m.workloads.InstrumentAll(m.logger, m.client, namespace)
+			if err != nil {
+				m.logger.Error(err, "instrument workload failed")
+			}
 		}
+		return
 	}
 
-	// TODO deal with error
-	// 对所有可访问的NS(跳过kube-system)添加注入标记
-	nsList, err := m.namespaces.InstrumentWithCfg(m.logger, m.client, m.Cfg, instrumentAll)
+	nsList, err := m.namespaces.InstrumentWithCfg(m.logger, m.client, m.Cfg, m.instrumentAll)
 	if err != nil {
 		m.logger.Error(err, "error instrument namespace")
 	}
-	// 同时向所有可访问的workload添加注入标记
+
 	for _, namespace := range nsList {
-		// TODO deal with error
-		err := m.workloads.InstrumentWithCfg(m.logger, m.client, namespace, m.Cfg, instrumentAll)
+		err := m.workloads.InstrumentWithCfg(m.logger, m.client, namespace, m.Cfg, m.instrumentAll)
 		if err != nil {
 			m.logger.Error(err, "error instrument workload", "namespace", namespace)
 		}
 	}
-}
-
-type SetupRule interface {
-	DisableList() []string
-	EnableList() []string
 }
 
 func getJsonMergePatchForInstrumentationLabel(enabled bool) []byte {


### PR DESCRIPTION
This PR make `Odigos` correctly handle environments defined in the K8s Pod Spec and combine them with the environments injected by `Odigos`.

For example:

1. The user defines Env: JAVA_TOOL_OPTIONS=-Xmx512m in the Deployment POD template Spec;
```yaml
spec:
  template:
    spec:
      containers:
      - name: xxx
        env:
        - name: JAVA_TOOL_OPTIONS
          value: "-Xmx512m"
```

2. After Odigos injection, the actual environment variable in the POD Spec will be: 
```yaml
spec:
  containers:
  - name: xxx
    env:
    - name: JAVA_TOOL_OPTIONS
      value: "-Xmx512m -javaagent:xxx"
```
3.  Later, the user adjusts Env in the Deployment POD template Spec;
```yaml
// ...
        env:
        - name: JAVA_TOOL_OPTIONS
          value: "-Xmx1024m"
```
4. After Odigos injection, the actual environment variable in the POD Spec will be correctly adjusted to Env: 
```yaml
spec:
  containers:
  - name: xxx
    env:
    - name: JAVA_TOOL_OPTIONS
      value: "-Xmx1024m -javaagent:xxx"
```

---

However, for environments that are not defined in the Pod Spec but are defined in the container (such as the ENV syntax in Dockerfile), `Odigos` still can not be able to maintain/update them correctly.

The default execution steps are as follows:

1. The user defines ENV JAVA_TOOL_OPTIONS=-Xmx512m in the Dockerfile.

> ENV JAVA_TOOL_OPTIONS=-Xmx512m

2. Odigos reads the environment variable and records it in RuntimeDetail.
3. The actual environment variable in the final POD Spec becomes Env: 

> JAVA_TOOL_OPTIONS=-Xmx512m -javaagent:xxx.

At this point, the result is correct, but can not be updated correctly later.

4. The user modifies the ENV defined in the Dockerfile
> JAVA_TOOL_OPTIONS=-Xmx1024m.
5. `Odigos` will still use the RuntimeDetail read during the last state, which causes the actual environment variable became
> JAVA_TOOL_OPTIONS=-Xmx512m -javaagent:xxx.

---
## Workaround

1. Defined the environment in POD Spec.
2. In the scenario where variables in the startup script are overwritten by `Odigos`, set the environment variable `ENABLE_OVERWRITE_USER_DEFINED_ENVS` to `true` to prevent `Odigos` from caching variables within the container; this will also cause the environment variables defined in the Dockerfile to become invalid.